### PR TITLE
AArch64 support now as complete as x86-64, chapter 18 (-3) passes

### DIFF
--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -44,12 +44,6 @@ jobs:
           git -C third_party clone --depth 1 --branch v2.5.0 https://github.com/CLIUtils/CLI11.git || true
           git -C third_party clone --depth 1 --branch v1.17.0 https://github.com/google/googletest.git || true
 
-      - name: Save third_party cache
-        uses: actions/cache@v3
-        with:
-          path: third_party
-          key: ${{ inputs.os }}-third_party
-
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ output/
 third_party/
 
 # Default names
-output.o
+*.o
 a.out
 .python-version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(boost)
 
-
 # CLI11
 FetchContent_Declare(
     cli11
@@ -132,7 +131,7 @@ target_link_libraries(rcc PRIVATE
 enable_testing()
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-add_executable(abi_test unittests/CodeGen/ABITest.cpp)
+add_executable(abi_test unittests/CodeGen/X86_64ABITest.cpp)
 target_link_libraries(abi_test PRIVATE GTest::gtest_main CodeGen ${llvm_libs})
 
 include(GoogleTest)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 Reaver C Compiler (`rcc`) is a C99 compiler. It features a lexer, parser,
 preprocessor, AST, and compiles to LLVM IR. It supports both x86 and AArch64.
 
-
 ## Why?
 
 For fun! We started [`v1.0`](https://github.com/saturn691/ReaverCompiler/tree/v1.0)
@@ -95,6 +94,23 @@ To run all unit tests, run the following commands:
 ```bash
 cd build
 ctest
+```
+
+### Running Integration Tests
+
+To run the provided integration tests, run the following command:
+
+```bash
+./test.py
+```
+
+To run the additional integration tests, run the following commands:
+
+```bash
+# Only run this once
+git submodule update --init --recursive
+# More options available. Does not pass all tests yet
+./writing-a-c-compiler-tests/test_compiler --chapter 18 --skip-invaliid build/rcc
 ```
 
 ## Credits

--- a/include/AST/Type.hpp
+++ b/include/AST/Type.hpp
@@ -234,6 +234,8 @@ public:
     bool operator<(const BaseType &other) const override;
 
     bool isComplete() const noexcept override;
+    std::string getParamName(size_t i) const noexcept;
+    const BaseType *getParamType(size_t i) const noexcept;
 
     Ptr<ParamType> params_;
     Ptr<BaseType> retType_;
@@ -255,7 +257,7 @@ public:
 
     bool isComplete() const noexcept override;
 
-    size_t size() const;
+    size_t size() const noexcept;
     const BaseType *at(size_t i) const;
 
     Params types_;

--- a/include/CodeGen/AArch64ABI.hpp
+++ b/include/CodeGen/AArch64ABI.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CodeGen/ABI.hpp"
+
+namespace CodeGen
+{
+
+class AArch64ABI : public ABI
+{
+public:
+    AArch64ABI(llvm::Module &module);
+
+    FunctionParamsInfo getFunctionParams(
+        llvm::Type *retType,
+        std::vector<llvm::Type *> &paramTypes) const override;
+    llvm::FunctionType *getFunctionType(
+        llvm::Type *retType,
+        std::vector<llvm::Type *> &paramTypes) const override;
+    std::vector<llvm::Type *> getParamType(llvm::Type *type) const override;
+    llvm::Align getTypeAlign(llvm::Type *type) const override;
+    unsigned getTypeSize(AST::Types type) const override;
+
+    bool useByVal() const override
+    {
+        return false;
+    }
+
+private:
+    llvm::Module &module_;
+};
+} // namespace CodeGen

--- a/include/CodeGen/ABI.hpp
+++ b/include/CodeGen/ABI.hpp
@@ -38,47 +38,8 @@ public:
     virtual std::vector<llvm::Type *> getParamType(llvm::Type *type) const = 0;
     virtual llvm::Align getTypeAlign(llvm::Type *type) const = 0;
     virtual unsigned getTypeSize(AST::Types type) const = 0;
+    virtual bool useByVal() const = 0;
 };
 
-class X86_64ABI : public ABI
-{
-public:
-    enum class ArgClass
-    {
-        INTEGER, // Integral types that fit in one of the GP registers
-        SSE,     // Types that fit into a vector register
-        SSEUP,   // Tail part of SSE
-        X87,     // 80-bit (rarely used in modern code), returned via x87 FPU
-        X87UP,   // Tail part of X87
-        COMPLEX_X87, // Complex long double
-        MEMORY,      // Passed by memory via the stack
-        NO_CLASS     // Types that don't fit into any of the above
-    };
 
-    struct ArgClassInfo
-    {
-        ArgClass cls = ArgClass::NO_CLASS;
-        unsigned size = 0;
-        unsigned align = 0;
-        bool multiple = false;
-    };
-    using ArgClasses = std::vector<ArgClassInfo>;
-
-    X86_64ABI(llvm::Module &module);
-
-    FunctionParamsInfo getFunctionParams(
-        llvm::Type *retType,
-        std::vector<llvm::Type *> &paramTypes) const override;
-    llvm::FunctionType *getFunctionType(
-        llvm::Type *retType,
-        std::vector<llvm::Type *> &paramTypes) const override;
-    std::vector<llvm::Type *> getParamType(llvm::Type *type) const override;
-    llvm::Align getTypeAlign(llvm::Type *type) const override;
-    unsigned getTypeSize(AST::Types type) const override;
-
-private:
-    ArgClasses getArgClassification(llvm::Type *type) const;
-    ArgClassInfo mergeClassifications(ArgClassInfo lhs, ArgClassInfo rhs) const;
-    llvm::Module &module_;
-};
 } // namespace CodeGen

--- a/include/CodeGen/CodeGenModule.hpp
+++ b/include/CodeGen/CodeGenModule.hpp
@@ -5,8 +5,9 @@
 #include <unordered_map>
 
 #include "AST/Visitor.hpp"
-#include "CodeGen/ABI.hpp"
+#include "CodeGen/AArch64ABI.hpp"
 #include "CodeGen/TypeChecker.hpp"
+#include "CodeGen/X86_64ABI.hpp"
 
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
@@ -31,7 +32,8 @@ public:
     CodeGenModule(
         std::string sourceFile,
         std::string outputFile,
-        TypeMap &typeMap);
+        TypeMap &typeMap,
+        std::string targetTriple);
     void emitLLVM();
     void emitObject();
     void optimize();

--- a/include/CodeGen/X86_64ABI.hpp
+++ b/include/CodeGen/X86_64ABI.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "CodeGen/ABI.hpp"
+
+namespace CodeGen
+{
+
+class X86_64ABI : public ABI
+{
+public:
+    enum class ArgClass
+    {
+        INTEGER, // Integral types that fit in one of the GP registers
+        SSE,     // Types that fit into a vector register
+        SSEUP,   // Tail part of SSE
+        X87,     // 80-bit (rarely used in modern code), returned via x87 FPU
+        X87UP,   // Tail part of X87
+        COMPLEX_X87, // Complex long double
+        MEMORY,      // Passed by memory via the stack
+        NO_CLASS     // Types that don't fit into any of the above
+    };
+
+    struct ArgClassInfo
+    {
+        ArgClass cls = ArgClass::NO_CLASS;
+        unsigned size = 0;
+        unsigned align = 0;
+        bool multiple = false;
+    };
+    using ArgClasses = std::vector<ArgClassInfo>;
+
+    X86_64ABI(llvm::Module &module);
+
+    FunctionParamsInfo getFunctionParams(
+        llvm::Type *retType,
+        std::vector<llvm::Type *> &paramTypes) const override;
+    llvm::FunctionType *getFunctionType(
+        llvm::Type *retType,
+        std::vector<llvm::Type *> &paramTypes) const override;
+    std::vector<llvm::Type *> getParamType(llvm::Type *type) const override;
+    llvm::Align getTypeAlign(llvm::Type *type) const override;
+    unsigned getTypeSize(AST::Types type) const override;
+
+    bool useByVal() const override
+    {
+        return true;
+    }
+
+private:
+    ArgClasses getArgClassification(llvm::Type *type) const;
+    ArgClassInfo mergeClassifications(ArgClassInfo lhs, ArgClassInfo rhs) const;
+    llvm::Module &module_;
+};
+} // namespace CodeGen

--- a/src/AST/Type.cpp
+++ b/src/AST/Type.cpp
@@ -199,6 +199,16 @@ bool FnType::isComplete() const noexcept
     return retType_->isComplete() && params_->isComplete();
 }
 
+std::string FnType::getParamName(size_t i) const noexcept
+{
+    return params_->types_.at(i).first;
+}
+
+const BaseType *FnType::getParamType(size_t i) const noexcept
+{
+    return params_->types_.at(i).second.get();
+}
+
 ParamType::ParamType(Params types) : types_(std::move(types))
 {
 }
@@ -267,7 +277,7 @@ bool ParamType::isComplete() const noexcept
     return true;
 }
 
-size_t ParamType::size() const
+size_t ParamType::size() const noexcept
 {
     return types_.size();
 }

--- a/src/CodeGen/AArch64ABI.cpp
+++ b/src/CodeGen/AArch64ABI.cpp
@@ -1,0 +1,248 @@
+#include "CodeGen/AArch64ABI.hpp"
+
+// Refer to
+// https://github.com/ARM-software/abi-aa/blob/main/aapcs64/aapcs64.rst
+// Unlike x86_64, LLVM handles register allocation of AArch64 mostly in the
+// backend. Therefore the rules are just rough.
+
+namespace CodeGen
+{
+/******************************************************************************
+ *                          Private methods                                   *
+ *****************************************************************************/
+
+namespace
+{
+
+/// Returns 0 for error
+size_t getAggregateNumElements(llvm::Type *type)
+{
+    if (type->isStructTy())
+    {
+        return type->getStructNumElements();
+    }
+    else if (type->isArrayTy())
+    {
+        return type->getArrayNumElements();
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+std::vector<llvm::Type *> flattenHFA(llvm::Type *t)
+{
+    // The test for homogeneity is applied after data layout is completed
+    std::vector<llvm::Type *> flatElements;
+
+    if (auto *structType = llvm::dyn_cast<llvm::StructType>(t))
+    {
+        for (size_t i = 0; i < structType->getNumElements(); i++)
+        {
+            auto v = flattenHFA(structType->getElementType(i));
+            flatElements.insert(flatElements.end(), v.begin(), v.end());
+        }
+    }
+    else if (auto *arrayType = llvm::dyn_cast<llvm::ArrayType>(t))
+    {
+        for (size_t i = 0; i < arrayType->getNumElements(); i++)
+        {
+            auto v = flattenHFA(arrayType->getElementType());
+            flatElements.insert(flatElements.end(), v.begin(), v.end());
+        }
+    }
+    else
+    {
+        flatElements.push_back(t);
+    }
+
+    return flatElements;
+}
+
+/// Homogeneous Floating-point Aggregates
+bool isHFA(llvm::Type *type)
+{
+    if (!type->isAggregateType())
+    {
+        return false;
+    }
+
+    std::vector<llvm::Type*> flatElements = flattenHFA(type);
+    if (flatElements.size() < 1 || flatElements.size() > 4)
+    {
+        return false;
+    }
+
+    return flatElements[0]->isFloatingPointTy() && std::equal(
+                                                       flatElements.begin() + 1,
+                                                       flatElements.end(),
+                                                       flatElements.begin());
+}
+
+/// Homogeneous Short-Vector Aggregates
+constexpr bool isHVA(llvm::Type *type)
+{
+    // e.g. float32x4_t
+    return false;
+}
+
+} // namespace
+
+/******************************************************************************
+ *                          Public methods                                    *
+ *****************************************************************************/
+
+AArch64ABI::AArch64ABI(llvm::Module &module) : module_(module)
+{
+}
+
+ABI::FunctionParamsInfo AArch64ABI::getFunctionParams(
+    llvm::Type *retType,
+    std::vector<llvm::Type *> &paramTypes) const
+{
+    // ABI 6.8.2: Parameter passing rules
+    std::vector<std::vector<llvm::Type *>> actualParamTypes;
+    bool structReturnInMemory = false;
+
+    // ABI 6.9: Result return
+    if (retType->isAggregateType())
+    {
+        auto paramType = getParamType(retType);
+        if (paramType[0]->isPointerTy())
+        {
+            actualParamTypes.push_back(paramType);
+            structReturnInMemory = true;
+            retType = llvm::Type::getVoidTy(module_.getContext());
+        }
+        else
+        {
+            // structs in LLVM are pointers. This is to pass by value.
+            retType = paramType[0];
+        }
+    }
+
+    // Stage A: Initialization (N/A, reg allocation handled in backend)
+    // In fact, we can handle them one at a time, without previous context
+    for (auto *paramType : paramTypes)
+    {
+        actualParamTypes.push_back(getParamType(paramType));
+    }
+
+    return {retType, actualParamTypes, structReturnInMemory};
+}
+
+llvm::FunctionType *AArch64ABI::getFunctionType(
+    llvm::Type *retType,
+    std::vector<llvm::Type *> &paramTypes) const
+{
+    auto actualParamTypes = getFunctionParams(retType, paramTypes);
+
+    std::vector<llvm::Type *> flatParamTypes;
+    for (const auto &paramTypes : actualParamTypes.paramTypes)
+    {
+        flatParamTypes.insert(
+            flatParamTypes.end(), paramTypes.begin(), paramTypes.end());
+    }
+
+    return llvm::FunctionType::get(
+        actualParamTypes.retType, flatParamTypes, false);
+}
+
+std::vector<llvm::Type *> AArch64ABI::getParamType(llvm::Type *type) const
+{
+    size_t typeSize = module_.getDataLayout().getTypeAllocSize(type);
+
+    // Stage B: Pre-padding and extension of arguments
+    if (!isHFA(type) && !isHVA(type) && typeSize > 16)
+    {
+        // B.4. Passed via memory
+        return {llvm::PointerType::get(type, 0)};
+    }
+
+    if (type->isAggregateType())
+    {
+        // B.5. Align to nearest multiple of 8
+        typeSize = llvm::alignTo(typeSize, 8);
+    }
+
+    // Stage C: Assignment of arguments to register and stack
+    // A lot of this happens in the backend. We only need aggregate
+    // handling.
+    if (isHFA(type))
+    {
+        // Decompose the HFA
+        auto v = flattenHFA(type);
+        return {llvm::ArrayType::get(v[0], v.size())};
+    }
+    else if (type->isAggregateType())
+    {
+        // LLVM takes care of everything else in the backend
+        // C.11. This could be { int, float } or { int, int } -> use GP regs
+        size_t regsRequired = typeSize / 8;
+        auto i64 = llvm::Type::getInt64Ty(module_.getContext());
+        if (regsRequired == 1)
+        {
+            return {i64};
+        }
+
+        return {llvm::ArrayType::get(i64, regsRequired)};
+    }
+
+    return {type};
+}
+
+llvm::Align AArch64ABI::getTypeAlign(llvm::Type *type) const
+{
+    // Opaque structs have no size
+    if (type->isStructTy() && type->getStructNumElements() == 0)
+    {
+        return llvm::Align(1);
+    }
+
+    // _Alignof returns minimum align (e.g. _Alignof(int[4]) = 4, but LLVM
+    // defaults to giving 16, as int[4] >= 16 bytes)
+    int align = module_.getDataLayout().getPrefTypeAlign(type).value();
+
+    return llvm::Align(align);
+}
+
+unsigned AArch64ABI::getTypeSize(AST::Types ty) const
+{
+    using Types = AST::Types;
+
+    switch (ty)
+    {
+    case Types::VOID:
+        return 0;
+    case Types::BOOL:
+        return 1;
+    case Types::CHAR:
+    case Types::UNSIGNED_CHAR:
+        return 8;
+    case Types::SHORT:
+    case Types::UNSIGNED_SHORT:
+        return 16;
+    case Types::INT:
+    case Types::UNSIGNED_INT:
+        return 32;
+    case Types::LONG:
+    case Types::UNSIGNED_LONG:
+        // ABI 10.1.2: This depends on ILP32/LP64/LLP64.
+        // We don't support Windows, so use LP64
+    case Types::LONG_LONG:
+    case Types::UNSIGNED_LONG_LONG:
+        return 64;
+
+    case Types::FLOAT:
+        return 32;
+    case Types::DOUBLE:
+        return 64;
+    case Types::LONG_DOUBLE:
+        return 128;
+    };
+
+    throw std::runtime_error("Unknown type");
+}
+
+} // namespace CodeGen

--- a/src/CodeGen/X86_64ABI.cpp
+++ b/src/CodeGen/X86_64ABI.cpp
@@ -1,4 +1,4 @@
-#include "CodeGen/ABI.hpp"
+#include "CodeGen/X86_64ABI.hpp"
 
 // Refer to
 // https://lafibre.info/images/doc/202402_intel_application_binary_interface.pdf
@@ -14,7 +14,7 @@ X86_64ABI::X86_64ABI(llvm::Module &module) : module_(module)
 }
 
 ABI::FunctionParamsInfo X86_64ABI::getFunctionParams(
-    llvm::Type *retType,
+    llvm:: Type *retType,
     std::vector<llvm::Type *> &paramTypes) const
 {
     // ABI 3.2.3: Parameter Passing

--- a/test.py
+++ b/test.py
@@ -474,9 +474,8 @@ def main():
     Path(OUTPUT_FOLDER).mkdir(parents=True, exist_ok=True)
     Path(BUILD_FOLDER).mkdir(parents=True, exist_ok=True)
 
-    if not make(silent=args.short):
-        exit(3)
-
+    # TODO: write function called setup()- make is a bit more complicated now
+    
     with JUnitXMLFile(J_UNIT_OUTPUT_FILE) as xml_file:
         run_tests(args, xml_file)
 

--- a/unittests/CodeGen/X86_64ABITest.cpp
+++ b/unittests/CodeGen/X86_64ABITest.cpp
@@ -1,7 +1,7 @@
-#include "CodeGen/ABI.hpp"
+#include "CodeGen/X86_64ABI.hpp"
 #include "gtest/gtest.h"
 
-class ABITest : public ::testing::Test
+class X86_64ABITest : public ::testing::Test
 {
 protected:
     void SetUp() override
@@ -20,7 +20,7 @@ protected:
     std::unique_ptr<CodeGen::ABI> abi_;
 };
 
-TEST_F(ABITest, getFunctionType_Basic)
+TEST_F(X86_64ABITest, getFunctionType_Basic)
 {
     auto retType = llvm::Type::getInt32Ty(*context_);
     auto paramTypes =
@@ -31,7 +31,7 @@ TEST_F(ABITest, getFunctionType_Basic)
     EXPECT_EQ(type->getReturnType(), llvm::Type::getInt32Ty(*context_));
 }
 
-TEST_F(ABITest, getFunctionType_only6IntRegs)
+TEST_F(X86_64ABITest, getFunctionType_only6IntRegs)
 {
     auto structType1Reg = llvm::StructType::create(*context_, "pair");
     structType1Reg->setBody(
@@ -119,7 +119,7 @@ TEST_F(ABITest, getFunctionType_only6IntRegs)
     }
 }
 
-TEST_F(ABITest, getFunctionType_retval)
+TEST_F(X86_64ABITest, getFunctionType_retval)
 {
     auto structType2Reg = llvm::StructType::create(*context_, "pair");
     structType2Reg->setBody(
@@ -139,7 +139,7 @@ TEST_F(ABITest, getFunctionType_retval)
              llvm::Type::getInt8Ty(*context_)}));
 }
 
-TEST_F(ABITest, getParamType_Basic)
+TEST_F(X86_64ABITest, getParamType_Basic)
 {
     auto type = abi_->getParamType(llvm::Type::getInt32Ty(*context_));
 
@@ -147,7 +147,7 @@ TEST_F(ABITest, getParamType_Basic)
     EXPECT_EQ(type[0], llvm::Type::getInt32Ty(*context_));
 }
 
-TEST_F(ABITest, getParamType_BasicStruct)
+TEST_F(X86_64ABITest, getParamType_BasicStruct)
 {
     auto structType = llvm::StructType::create(*context_, "pair");
     structType->setBody(
@@ -160,7 +160,7 @@ TEST_F(ABITest, getParamType_BasicStruct)
     EXPECT_EQ(type[1], llvm::Type::getDoubleTy(*context_));
 }
 
-TEST_F(ABITest, getParamType_AlignStruct)
+TEST_F(X86_64ABITest, getParamType_AlignStruct)
 {
     auto structType = llvm::StructType::create(*context_, "pair");
     structType->setBody({
@@ -173,7 +173,7 @@ TEST_F(ABITest, getParamType_AlignStruct)
     EXPECT_EQ(type[0], llvm::Type::getInt64Ty(*context_));
 }
 
-TEST_F(ABITest, getParamType_ArrayStruct)
+TEST_F(X86_64ABITest, getParamType_ArrayStruct)
 {
     auto structType = llvm::StructType::create(*context_, "pair");
     structType->setBody(
@@ -185,13 +185,13 @@ TEST_F(ABITest, getParamType_ArrayStruct)
     EXPECT_EQ(type[1], llvm::Type::getIntNTy(*context_, 24));
 }
 
-TEST_F(ABITest, getTypeAlign)
+TEST_F(X86_64ABITest, getTypeAlign)
 {
     auto align = abi_->getTypeAlign(llvm::Type::getInt32Ty(*context_));
     EXPECT_EQ(align, llvm::Align(4));
 }
 
-TEST_F(ABITest, getTypeSize)
+TEST_F(X86_64ABITest, getTypeSize)
 {
     auto size = abi_->getTypeSize(AST::Types::INT);
     EXPECT_EQ(size, 32);


### PR DESCRIPTION
Split ABI.hpp into X86_64ABI.hpp and AArch64ABI.hpp
Add support for AArch64, which now is as feature complete as x86-64.